### PR TITLE
Update gtk dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ travis-ci = { repository = "qdot/libappindicator-rs" }
 
 [dependencies]
 log= "0.4.8"
-glib= "0.9.2"
-gtk= "0.8.1"
-gtk-sys= "0.9.2"
+glib= "0.10.0"
+gtk= "0.9.0"
+gtk-sys= "0.10.0"
 libappindicator-sys= "0.4.0"
 
 [[example]]

--- a/examples/libappindicator-example.rs
+++ b/examples/libappindicator-example.rs
@@ -14,7 +14,7 @@ fn main() {
     indicator.set_icon_theme_path(icon_path.to_str().unwrap());
     indicator.set_icon_full("rust-logo-64x64-blk", "icon");
     let mut m = gtk::Menu::new();
-    let mi = gtk::CheckMenuItem::new_with_label("Hello RUST");
+    let mi = gtk::CheckMenuItem::with_label("Hello RUST");
     mi.connect_activate(|_| {
         gtk::main_quit();
     });


### PR DESCRIPTION
This would require qdot/libappindicator-sys#8 to be merged and publishing that as a new version of libappindicator-sys.