### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libappindicator"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Kyle Machulis <kyle@nonpolynomial.com>"]
 description = "Rust safe bindings for libappindicator"
 license = "LGPL-2.1/LGPL-3.0"


### PR DESCRIPTION
Requires wusyong/libappindicator-sys#10 with version bump to 0.6.0 or wusyong/libappindicator-sys#12.

I did not see wusyong/libappindicator-sys#10 before opening my PR, sorry about that.